### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/nalemess/af6b75bc-b132-471d-940b-ccc28c7a27c6/dc6d9b42-9ee7-4642-a2d4-74db5e744a6a/_apis/work/boardbadge/810ef46d-55cc-48b9-a13a-2c5eef63d03e)](https://dev.azure.com/nalemess/af6b75bc-b132-471d-940b-ccc28c7a27c6/_boards/board/t/dc6d9b42-9ee7-4642-a2d4-74db5e744a6a/Microsoft.RequirementCategory)
 # Olá, Mundo!
  Primeiro repositório 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/nalemess/af6b75bc-b132-471d-940b-ccc28c7a27c6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.